### PR TITLE
Initial ActivityPub Maint WG charter template.

### DIFF
--- a/ap-maintenance-wg-charter.html
+++ b/ap-maintenance-wg-charter.html
@@ -1,0 +1,529 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <meta charset="utf-8">
+
+    <title>ActivityPub Maintenance Working Group Charter</title>
+
+    <link rel="stylesheet" href="https://www.w3.org/2005/10/w3cdoc.css" type="text/css" media="screen">
+    <link rel="stylesheet" type="text/css" href="https://www.w3.org/OldGuide/pubrules-style.css">
+    <link rel="stylesheet" type="text/css" href="https://www.w3.org/2006/02/charter-style.css">
+    <style>
+      main {
+        max-width: 60em;
+        margin: 0 auto;
+      }
+
+      ul#navbar {
+        font-size: small;
+      }
+
+      dt.spec {
+        font-weight: bold;
+      }
+
+      dt.spec new {
+        background: yellow;
+      }
+
+      ul.out-of-scope > li {
+        font-weight: bold;
+      }
+
+      ul.out-of-scope > li > ul > li{
+        font-weight: normal;
+      }
+
+      .issue {
+        background: cornsilk;
+        font-style: italic;
+      }
+
+      .todo {
+        color: #900;
+      }
+
+      footer {
+        font-size: small;
+      }
+    </style>
+  </head>
+  <body>
+    <header id="header">
+      <aside>
+        <ul id="navbar">
+          <li><a href="#background">Background</a></li>
+          <li><a href="#scope">Scope</a></li>
+          <li><a href="#deliverables">Deliverables</a></li>
+		  <li><a href="#success-criteria">Success Criteria</a></li>
+          <li><a href="#coordination">Coordination</a></li>
+          <li><a href="#participation">Participation</a></li>
+          <li><a href="#communication">Communication</a></li>
+          <li><a href="#decisions">Decision Policy</a></li>
+          <li><a href="#patentpolicy">Patent Policy</a></li>
+          <li><a href="#licensing">Licensing</a></li>
+          <li><a href="#about">About this Charter</a></li>
+        </ul>
+      </aside>
+      <p>
+        <a href="https://www.w3.org/"><img alt="W3C" height="48" src="https://www.w3.org/Icons/w3c_home" width="72"></a>
+      </p>
+    </header>
+
+    <main>
+      <h1 id="title"><i class="todo">DRAFT</i> ActivityPub Maintenance Working Group Charter</h1>
+      <!-- replace DRAFT with PROPOSED when the AC reivew starts -->
+      <!-- delete PROPOSED after AC review completed -->
+
+      <p class="mission">The <strong>mission</strong> of the
+          <a href="https://www.w3.org/groups/wg/ap/">ActivityPub Maintenance Working Group</a>
+        is to maintain the ActivityPub, ActivityStreams and ActivityVocabulary
+        W3C Recommendations, as well as related Notes.
+      </p>
+
+      <div class="noprint">
+        <p class="join">
+          <a href="https://www.w3.org/groups/wg/ap/join/">Join the ActivityPub Maintenance Working Group.</a>
+        </p>
+      </div>
+
+      <!-- replace "draft charter" with "proposed charter" when the AC review starts -->
+      <!-- delete the GH link after AC review completed -->
+      <p style="padding: 0.5ex; border: 1px solid green"> This proposed charter is available
+      on <i class="todo"><a href="https://github.com/@@/@@">GitHub</a>.
+
+    Feel free to raise <a href="https://github.com/@@/@@/issues">issues</a></i>.
+          </p>
+
+      <div id="details">
+        <table class="summary-table">
+          <tr id="Status">
+            <th>
+              Charter Status
+            </th>
+            <td>
+              See the <a href="https://www.w3.org/groups/wg/ap/charters/">group status page</A> and
+              <a href="#history">detailed change history</a>.</i>
+            </td>
+          </tr>
+          <tr id="Duration">
+            <th>
+              Start date
+            </th>
+            <td>
+              <i class="todo">
+                [dd monthname yyyy] (date of the "Call for Participation", when
+                the charter is approved)
+              </i>
+            </td>
+          </tr>
+          <tr id="CharterEnd">
+            <th>
+              End date
+            </th>
+            <td>
+              <i class="todo">[dd monthname yyyy]</i> (Start date + 2 years)
+            </td>
+          </tr>
+          <tr>
+            <th>
+              Chairs
+            </th>
+            <td>
+              <i class="todo">[chair name] (affiliation)</i>
+            </td>
+          </tr>
+          <tr>
+            <th>
+              Team Contacts
+            </th>
+            <td>
+              <span class="todo"><a href="mailto:">[team contact name]</a></span>
+              <i class="todo">(0.1 <abbr title="Full-Time Equivalent">FTE</abbr>)</i>
+            </td>
+          </tr>
+          <tr>
+            <th>
+              Meeting Schedule
+            </th>
+            <td>
+              <strong>Teleconferences:</strong> <i class="todo">topic-specific calls may be held</i>
+              or <i class="todo">something else</i>
+              <br>
+              <strong>Face-to-face:</strong> we will meet during the W3C's annual Technical Plenary week;
+              additional face-to-face meetings may be scheduled by consent of the participants, usually
+              no more than 3 per year.
+            </td>
+          </tr>
+        </table>
+
+      </div>
+
+      <div id="background" class="background">
+        <h2>Motivation and Background</h2>
+        <p>
+          In the past few years, the Social Web Community Group acted as a
+          maintainer for Social Web related specifications published by W3C.
+          This Working Group would maintain specifically the ActivityPub related
+          Recommendations and Notes.
+        </p>
+      </div>
+
+      <section id="scope" class="scope">
+        <h2>Scope</h2>
+
+        <p>
+          The Working Group will maintain the <a href="https://www.w3.org/TR/activitypub/">ActivityPub</a> protocol,
+          as well as the <a href="https://www.w3.org/TR/activitystreams-core/">Activity Streams</a> and
+          <a href="https://www.w3.org/TR/activitystreams-vocabulary/">Activity Vocabulary</a> data models on
+          which it depends, as well as related Notes.
+
+        <section id="section-out-of-scope">
+          <h3 id="out-of-scope">Out of Scope</h3>
+          <p>
+            Changes that add new functionality
+            (<a href="https://www.w3.org/policies/process/#class-4">class 4</a>)
+            are out of scope.
+          </p>
+        </section>
+
+      </section>
+
+      <section id="deliverables">
+        <h2>
+          Deliverables
+        </h2>
+
+        <p>Updated document status is available on the
+            <a href="https://www.w3.org/groups/wg/ap/publications/">group publication status page</a>.
+        </p>
+
+        <section id="normative">
+          <h3>
+            Normative Specifications
+          </h3>
+          <p>
+            The Working Group will deliver the following W3C normative specifications:
+          </p>
+          <dl>
+            <dt id="activity" class="spec"><a href="https://www.w3.org/TR/activitypub/">ActivityPub</a></dt>
+            <dd>
+              <p><b>Adopted Draft:</b> @@to be filled later@@
+                <p><b>Exclusion Draft:</b>  @@to be filled later@@
+                Associated @@to be filled later@@
+                <p><b>Exclusion Draft Charter:</b>  @@to be filled later@@
+
+            </dd>
+            <dt id="activity" class="spec"><a href="https://www.w3.org/TR/activitystreams-core/">Activity Streams</a></dt>
+            <dd>
+              <p><b>Adopted Draft:</b> @@to be filled later@@
+              <p><b>Exclusion Draft:</b>  @@to be filled later@@
+              Associated @@to be filled later@@
+              <p><b>Exclusion Draft Charter:</b>  @@to be filled later@@
+            </dd>
+            <dt id="activity" class="spec"><a href="https://www.w3.org/TR/activitystreams-vocabulary/">Activity Vocabulary</a></dt>
+            <dd>
+              <p><b>Adopted Draft:</b> @@to be filled later@@
+                <p><b>Exclusion Draft:</b>  @@to be filled later@@
+                Associated @@to be filled later@@
+                <p><b>Exclusion Draft Charter:</b>  @@to be filled later@@
+
+            </dd>
+          </dl>
+        </section>
+      </section>
+
+	<section id="success-criteria">
+	  <h2>Success Criteria</h2>
+
+    <p>
+      In order to update the Recommendation, each substantive change is expected
+      to have <a href="https://www.w3.org/Consortium/Process/#implementation-experience">at least
+      two independent implementations</a> of every feature defined in the
+      specification, where interoperability can be verified by passing open test suites.
+    </p>
+
+    <p>
+      Each substantive change should contain a section detailing all known
+      security and privacy implications for implementers, authors, and end users.
+    </p>
+
+    <p>
+      To promote interoperability, all changes made to specifications should have
+      <a href="https://www.w3.org/2019/02/testing-policy.html">tests</a>.
+    </p>
+
+    <p>
+      This Working Group expects to follow the TAG <a href="https://www.w3.org/TR/design-principles/">Web
+        Platform Design Principles</a>.
+    </p>
+  	</section>
+
+      <section id="coordination">
+        <h2>Coordination</h2>
+        <p>For all specifications, this Working Group will seek
+          <a href="https://www.w3.org/Guide/documentreview/#how_to_get_horizontal_review">horizontal review</a> for
+          accessibility, internationalization, privacy, and security with the
+          relevant Working and Interest Groups, and with the
+          <a href="https://www.w3.org/groups/other/tag/" title="Technical Architecture Group">TAG</a>.
+          Invitation for review must be issued during each major standards-track
+          document transition, including
+          <a href="https://www.w3.org/policies/process/#RecsWD" title="First Public Working Draft">FPWD</a>.
+          The Working Group is encouraged to engage collaboratively with the
+          horizontal review groups throughout development of each specification.
+          The Working Group is advised to seek a review at least 3 months before
+          first entering
+          <a href="https://www.w3.org/policies/process/#RecsCR" title="Candidate Recommendation">CR</a>
+          and is encouraged to proactively notify the horizontal review groups
+          when major changes occur in a specification following a review.
+        </p>
+
+        <p>
+          This group is expected to coordinate with the
+          <a href="https://www.w3.org/groups/cg/socialcg/">Social Web Incubator Community Group</a>
+          on consensus-based proposals related to content changes for the
+          ActivityPub Maintenance Working Group Deliverables.
+          The Chairs of this group should reject proposals that are incompatible
+          with this Charter.
+        </p>
+
+        <section>
+          <h3 id="w3c-coordination">W3C Groups</h3>
+          <dl>
+            <dt><a href="https://www.w3.org/groups/cg/socialcg/">Social Web Incubator Community Group</a></dt>
+            <dd>@@to be filled later@@</dd>
+          </dl>
+        </section>
+
+        <section>
+          <h3 id="external-coordination">External Organizations</h3>
+          <dl>
+            <dt><a href=""><i class="todo">[other name]</i> Working Group</a></dt>
+            <dd><i class="todo">[specific nature of liaison]</i></dd>
+          </dl>
+        </section>
+      </section>
+
+      <section class="participation">
+        <h2 id="participation">
+          Participation
+        </h2>
+        <p>
+          To be successful, this Working Group is expected to have 6 or more active
+          participants for its duration, including representatives from the key
+          implementors of this specification, and active Editors and Test Leads
+          for each specification. The Chairs, specification Editors, and Test
+          Leads are expected to contribute half of a working day per week towards
+          the Working Group. There is no minimum requirement for other Participants.
+        </p>
+        <p>
+          The group encourages questions, comments and issues on its public
+          mailing lists and document repositories, as described in
+          <a href='#communication'>Communication</a>.
+        </p>
+        <p>
+          The group also welcomes non-Members to contribute technical submissions
+          for consideration upon their agreement to the terms of the
+          <a href="https://www.w3.org/policies/patent-policy/">W3C Patent Policy</a>.
+        </p>
+        <p>Participants in the group are required (by the
+          <a href="https://www.w3.org/policies/process/#ParticipationCriteria">W3C Process</a>)
+            to follow the W3C <a href="https://www.w3.org/policies/code-of-conduct/">Code of Conduct</a>.
+        </p>
+      </section>
+
+      <section id="communication">
+        <h2>
+          Communication
+        </h2>
+        <p id="public">
+          Technical discussions for this Working Group are conducted in
+          <a href="https://www.w3.org/policies/process/#confidentiality-levels">public</a>:
+          the meeting minutes from teleconference and face-to-face meetings will
+          be archived for public review, and technical discussions and issue
+          tracking will be conducted in a manner that can be both read and
+          written to by the general public. Working Drafts and Editor's Drafts
+          of specifications will be developed in public repositories and may
+          permit direct public contribution requests.
+          The meetings themselves are not open to public participation, however.
+        </p>
+        <p>
+          Information about the group (including details about deliverables,
+          issues, actions, status, participants, and meetings)
+          will be available from the <a href="">ActivityPub Maintenance Working Group home page.</a>
+        </p>
+        <p>
+          Most ActivityPub Maintenance Working Group teleconferences will focus on discussion
+          of particular specifications, and will be conducted on an as-needed basis.
+        </p>
+        <p>
+          This group primarily conducts its technical work  <i class="todo">pick
+          one, or both, as appropriate:</i> on the public mailing list
+          <a class="todo" id="public-name" href="mailto:public-[email-list]@w3.org">public-<i class="todo">[email-list]</i>@w3.org</a>
+          (<a class="todo" href="https://lists.w3.org/Archives/Public/public-[email-list]/">archive</a>)
+          <i class="todo">or</i> on <a class="todo" id="public-github" href="[link to Github repo]">GitHub issues</a>.
+          The public is invited to review, discuss and contribute to this work.
+        </p>
+        <p>
+          The group may use a Member-confidential mailing list for administrative
+          purposes and, at the discretion of the Chairs and members of the group,
+          for member-only discussions in special cases when a participant requests
+          such a discussion.
+        </p>
+      </section>
+
+      <section id="decisions">
+        <h2>
+          Decision Policy
+        </h2>
+        <p>
+          This group will seek to make decisions through consensus and due process,
+          per the
+          <a href="https://www.w3.org/policies/process/#Consensus">W3C Process Document (section 5.2.1, Consensus)</a>.
+          Typically, an editor or other participant makes an initial proposal,
+          which is then refined in discussion with members of the group and other
+          reviewers, and consensus emerges with little formal voting being required.
+        </p>
+        <p>
+          However, if a decision is necessary for timely progress and consensus
+          is not achieved after careful consideration of the range of views
+          presented, the Chairs may call for a group vote and record a decision
+          along with any objections.
+        </p>
+        <p>
+          To afford asynchronous decisions and organizational deliberation, any
+          resolution (including publication decisions) taken in a face-to-face
+          meeting or teleconference will be considered provisional.
+
+          A call for consensus (CfC) will be issued for all resolutions (for
+          example, via email, GitHub issue or web-based survey), with a response
+          period from <span id='cfc'><i>10 working days</i></span>, depending on
+          the chair's evaluation of the group consensus on the issue.
+
+          If no objections are raised by the end of the response period, the
+          resolution will be considered to have consensus as a resolution of the
+          Working Group.
+        </p>
+        <p>
+          All decisions made by the group should be considered resolved unless
+          and until new information becomes available or unless reopened at the
+          discretion of the Chairs.
+        </p>
+        <p>
+          This charter is written in accordance with the
+          <a href="https://www.w3.org/policies/process/#Votes">W3C Process Document (Section 5.2.3, Deciding by Vote)</a>
+          and includes no voting procedures beyond what the Process Document requires.
+        </p>
+      </section>
+
+      <section id="patentpolicy">
+
+        <h2>
+          Patent Policy
+        </h2>
+        <p>
+          This Working Group operates under the
+          <a href="https://www.w3.org/policies/patent-policy/">W3C Patent Policy</a>
+          (Version of 15 September 2020). To promote the widest adoption of Web
+          standards, W3C seeks to issue Web specifications that can be implemented,
+          according to this policy, on a Royalty-Free basis.
+
+          For more information about disclosure obligations for this group, please see the
+          <a href="https://www.w3.org/groups/wg/ap/ipr/">licensing information</a>.
+        </p>
+
+      </section>
+
+      <section id="licensing">
+        <h2>Licensing</h2>
+        <p>This Working Group will use the
+          <a href="https://www.w3.org/copyright/software-license/">W3C Software and Document license</a> for all its deliverables.</p>
+      </section>
+
+      <section id="about">
+        <h2>
+          About this Charter
+        </h2>
+        <p>
+          This charter has been created according to
+          <a href="https://www.w3.org/policies/process/#GAGeneral">section 3.4</a>
+          of the <a href="https://www.w3.org/policies/process/">Process Document</a>.
+          In the event of a conflict between this document or the provisions of
+          any charter and the W3C Process, the W3C Process shall take precedence.
+        </p>
+
+        <section id="history">
+          <h3>
+            Charter History
+          </h3>
+
+          <p>The following table lists details of all changes from the initial
+            charter, per the <a href="https://www.w3.org/policies/process/#CharterReview">W3C
+              Process Document (section 4.3, Advisory Committee Review of a Charter)</a>:
+          </p>
+
+          <table class="history">
+            <tbody>
+              <tr>
+                <th>
+                  Charter Period
+                </th>
+                <th>
+                  Start Date
+                </th>
+                <th>
+                  End Date
+                </th>
+                <th>
+                  Changes
+                </th>
+              </tr>
+              <tr>
+                <th>
+                  <a class="todo" href="">Initial Charter</a>
+                </th>
+                <td>
+                  <i class="todo">[dd monthname yyyy]</i>
+                </td>
+                <td>
+                  <i class="todo">[dd monthname yyyy] (start +2 years)</i>
+                </td>
+                <td>
+                  <i class="todo">none</i>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+
+        <section id="changelog">
+          <h3>Change log</h3>
+
+          <!-- Use this section for changes _after_ the charter was approved by W3C. -->
+          <p>Changes to this document are documented in this section.</p>
+          <!--
+          <dl id='changes'>
+            <dt>YYYY-MM-DD</dt>
+            <dd>[changes]]</dd>
+          </dl>
+          -->
+        </section>
+      </section>
+    </main>
+
+    <hr>
+
+    <footer>
+      <address>
+        <i class="todo"><a href="mailto:">[team contact name]</a></i>
+      </address>
+
+<p class="copyright">Copyright © 2024 <a href="https://www.w3.org/">World Wide Web Consortium</a>.<br>
+  <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup>
+  <a href="https://www.w3.org/policies/#disclaimers">liability</a>,
+  <a href="https://www.w3.org/policies/#trademarks">trademark</a> and
+      <a rel="license" href="https://www.w3.org/copyright/software-license/" title="W3C Software and Document Notice and License">permissive document license</a> rules apply.</p>
+    </footer>
+
+  </body>
+</html>

--- a/ap-maintenance-wg-charter.html
+++ b/ap-maintenance-wg-charter.html
@@ -240,7 +240,7 @@
       In order to update the Recommendation, each substantive change is expected
       to have <a href="https://www.w3.org/Consortium/Process/#implementation-experience">at least
       two independent implementations</a> of every feature defined in the
-      specification, where interoperability can be verified by passing open test suites.
+      specification, where interoperability can be verified by passing open test suites, and two or more implementations interoperating with each other.
     </p>
 
     <p>


### PR DESCRIPTION
This is a sample (to be discussed with the CG) charter template for the continuing discussion of a potential Working Group, based on a minimal stock W3C template.

Notes:
* Narrowly scoped as an ActivityPub (and ActivityStreams and ActivityVocabulary on which it depends) Maintenance group.