### PR TITLE
Add CfC language from earlier FEP-37f2

### DIFF
--- a/CGCharter-1727386911.html
+++ b/CGCharter-1727386911.html
@@ -214,20 +214,18 @@
     <h2 id="decision">
       Decision Process
     </h2>
-    <p class="remove">
-      If the decision policy is documented somewhere, update this section accordingly to link to it.
-    </p>
     <p>
       This group will seek to make decisions where there is consensus. Groups
       are free to decide how to make decisions (e.g. Participants who have
       earned Committer status for a history of useful contributions assess
       consensus, or the Chair assesses consensus, or where consensus isn't
-      clear there is a Call for Consensus [CfC] to allow multi-day online
-      feedback for a proposed course of action). It is expected that
+      clear there is a Call for Consensus [CfC] (see below) to allow multi-day
+      online feedback for a proposed course of action). It is expected that
       participants can earn Committer status through a history of valuable
-      contributions as is common in open source projects. After discussion and
-      due consideration of different opinions, a decision should be publicly
-      recorded (where GitHub is used as the resolution of an Issue).
+      discursive contributions as is common in open source projects.
+      After discussion and due consideration of different opinions, a decision 
+      should be publicly recorded (where GitHub is used as the resolution 
+      of an Issue).
     </p>
     <p>
       If substantial disagreement remains (e.g. the group is divided) and the
@@ -241,15 +239,33 @@
       ahead with.
     </p>
     <p>
-      Any decisions reached at any meeting are tentative and should be recorded
-      in a GitHub Issue for groups that use GitHub and otherwise on the group's
-      public mail list. Any group participant may object to a decision reached
-      at an online or in-person meeting within 7 days of publication of the
-      decision provided that they include clear technical reasons for their
-      objection. The Chairs will facilitate discussion to try to resolve the
-      objection according to this decision process.
+      To afford asynchronous decisions and organizational deliberation, any 
+      resolution (including publication decisions) taken in a face-to-face 
+      meeting or teleconference will be considered provisional.
+      A call for consensus (CfC) will be issued for all resolutions via 
+      email to public-swicg@w3.org, preferably with the abbreviation CfC early
+      in the subject line to catch more attention.
     </p>
     <p>
+      Any group participant may object to a 
+      decision reached at an online or in-person meeting within 14 days of 
+      publication of the decision, provided that they include 
+      clear reasons for their objection grounded in the scope and documented
+      goals of the CG and its work items.
+    </p>
+    <h3 id="calls-for-consensus">
+      Calls for Consensus
+    </h3>
+    <p>  
+      The presence of formal resolutions will be indicated by a "CFC" prefix in the subject line of an email on the list.
+      Additional outreach to community venues for more affirmative consent is strongly encouraged.
+      There will be a response period of 14 days.
+      If no sustained objections are raised by the end of the response period, the resolution will be considered to have consensus as a resolution of the Community Group, i.e. a group decision.
+      All decisions made by the group should be considered resolved unless and until new information becomes available or unless reopened at the discretion of the Chairs or the Director.
+    </p>
+    <p>
+      The Chairs will facilitate discussion to try to resolve the
+      objection according to this decision process.
       It is the Chairs' responsibility to ensure that the decision process is
       fair, respects the consensus of the CG, and does not unreasonably favour
       or discriminate against any group participant or their employer.

--- a/CGCharter-1727386911.html
+++ b/CGCharter-1727386911.html
@@ -266,7 +266,7 @@
       Calls for Consensus
     </h3>
     <p>  
-      The presence of formal resolutions will be indicated by a "CFC" prefix in
+      The presence of formal resolutions will be indicated by a "CfC" prefix in
       the subject line of an email on the list. Additional outreach to community
       venues for more affirmative consent is strongly encouraged. There will be
       a response period of 14 days. If no sustained objections are raised by the

--- a/CGCharter-1727386911.html
+++ b/CGCharter-1727386911.html
@@ -49,17 +49,22 @@
       </li>
     </ul>
     <p>
-      The Social Web Incubator Community Group (also known as SocialCG, or SWICG) is the successor of the Social Web Working Group, which ran from 2014 to 2017.
+      The Social Web Incubator Community Group (also known as SocialCG, or
+      SWICG) is the successor of the Social Web Working Group, which ran from
+      2014 to 2017.
     </p>
     <h2 id="goals">
       Goals
     </h2>
     <ul>
       <li>
-        Provide space to collaborate and coordinate for implementors who are building on any of the specifications published by the Social Web WG (2014-2017), and related technologies.
+        Provide space to collaborate and coordinate for implementors who are
+        building on any of the specifications published by the Social Web WG
+        (2014-2017), and related technologies.
       </li>
       <li>
-        Incubate new proposals which build on or complement the Social Web WG recommendations.
+        Incubate new proposals which build on or complement the Social Web WG
+        recommendations.
       </li>
     </ul>
   
@@ -201,15 +206,19 @@
       Transparency
     </h2>
     <p>
-      The group will conduct all of its technical work in public, e.g.
-      on the <a href="https://lists.w3.org/Archives/Public/public-swicg/">public-swicg@w3.org mailing list</a>,
-      <a href="https://www.w3.org/wiki/SocialCG">w3.org SocialCG wiki</a>,
-      and git repositories cloned in the <a href="https://github.com/swicg">github.com/swicg/ Organization</a>
+      The group will conduct all of its technical work in public, e.g. on the <a
+      href="https://lists.w3.org/Archives/Public/public-swicg/">public-swicg@w3.org
+      mailing list</a>,
+      <a href="https://www.w3.org/wiki/SocialCG">w3.org SocialCG wiki</a>, and
+      git repositories cloned in the <a
+      href="https://github.com/swicg">github.com/swicg/ Organization</a>
       .
     </p>
     <p>
       Meetings may be restricted to Community Group participants, but a public
-      summary or minutes must be posted to the <a href="https://lists.w3.org/Archives/Public/public-swicg/">public-swicg@w3.org mailing list</a>.
+      summary or minutes must be posted to the <a
+      href="https://lists.w3.org/Archives/Public/public-swicg/">public-swicg@w3.org
+      mailing list</a>.
     </p>
     <h2 id="decision">
       Decision Process
@@ -257,11 +266,15 @@
       Calls for Consensus
     </h3>
     <p>  
-      The presence of formal resolutions will be indicated by a "CFC" prefix in the subject line of an email on the list.
-      Additional outreach to community venues for more affirmative consent is strongly encouraged.
-      There will be a response period of 14 days.
-      If no sustained objections are raised by the end of the response period, the resolution will be considered to have consensus as a resolution of the Community Group, i.e. a group decision.
-      All decisions made by the group should be considered resolved unless and until new information becomes available or unless reopened at the discretion of the Chairs or the Director.
+      The presence of formal resolutions will be indicated by a "CFC" prefix in
+      the subject line of an email on the list. Additional outreach to community
+      venues for more affirmative consent is strongly encouraged. There will be
+      a response period of 14 days. If no sustained objections are raised by the
+      end of the response period, the resolution will be considered to have
+      consensus as a resolution of the Community Group, i.e. a group decision.
+      All decisions made by the group should be considered resolved unless and
+      until new information becomes available or unless reopened at the
+      discretion of the Chairs or the Director.
     </p>
     <p>
       The Chairs will facilitate discussion to try to resolve the


### PR DESCRIPTION
Apologies if I missed anything or garbled language from either input document! Just wanted to get a starting point, feel free to suggest-edit aggressively.

For context see [the CfC from last Fall](https://codeberg.org/fediverse/fep/src/branch/main/fep/37f2/fep-37f2.md) announced [on the mailing list](https://lists.w3.org/Archives/Public/public-swicg/2023Sep/0118.html).

This starting point MAY or MAY NOT be enough to live up to PLH's comment in our meeting friday (from the minutes):

> The staged approach implies that the CG is able to make decisions.
> We need a charter for the CG to be able to do that. Since this staging 
> process involves a Working Group, this process must be approved by a
> Working Group. So we need charter for the CG and a chartered and 
> existing WG to really make this work.
      
I recommend people keep that in mind and use "suggest changes" to add sentences or even paragraphs if they think this section needs to be more explicit for the CG/WG work item document to work!