### PR TITLE
feat: add scope of work

### DIFF
--- a/CGCharter-1727386911.html
+++ b/CGCharter-1727386911.html
@@ -67,7 +67,7 @@
       Scope of Work
     </h2>
     <p>
-      The group will maintain errata and editor&apos;s drafts for the following recommendations from the Social Web Working Group:
+      The group will maintain errata and corrected drafts, consisting of the published document with errata applied, for the following recommendations from the Social Web Working Group:
     </p>
     <ul>
       <li>ActivityPub</li>
@@ -79,7 +79,7 @@
       <li>WebSub</li>
     </ul>
     <p>
-      It will maintain errata and editor&apos;s drafts for the following Notes from the Social Web Working Group:
+      It will maintain errata and corrected drafts, consisting of the published document with errata applied, for the following Notes from the Social Web Working Group:
     </p>
     <ul>
       <li>JF2</li>

--- a/CGCharter-1727386911.html
+++ b/CGCharter-1727386911.html
@@ -97,7 +97,7 @@
       The group will develop extensions to ActivityPub and Activity Streams 2.0, and other specifications as needed, to address new use cases and requirements.
     </p>
     <p>
-      The group will develop and document integration between ActivityPub and other protocols in a social web stack, such as Webfinger, HTML, and HTTP Signature.
+      The group will develop and document integration between ActivityPub and other protocols, such as Webfinger, HTML, and HTTP Signature.
     </p>
     <p>
       The group will develop and support the development of test suites and reference implementations for the above specifications and extensions.

--- a/CGCharter-1727386911.html
+++ b/CGCharter-1727386911.html
@@ -62,20 +62,51 @@
         Incubate new proposals which build on or complement the Social Web WG recommendations.
       </li>
     </ul>
-  
+
     <h2 id="scope-of-work">
       Scope of Work
     </h2>
-    <p class="remove">
-      {TBD: Describe topics that are in scope. For specifications that the CLA
-      patent section applies to, it is helpful to describe the scope in a way
-      that it is clear what types of technologies will be defined in
-      specifications, as opposed to adoption by reference or underlying
-      technology not defined in the proposed spec. Key use cases are often
-      helpful in describing scope. If no specifications will be defined in the
-      group that the CLA patent section applies to, the charter should clearly
-      state that. A clear scope is particularly important where patent
-      licensing obligations may apply.}
+    <p>
+      The group will maintain errata and editor&apos;s drafts for the following recommendations from the Social Web Working Group:
+    </p>
+    <ul>
+      <li>ActivityPub</li>
+      <li>Activity Streams 2.0 Core</li>
+      <li>Activity Vocabulary</li>
+      <li>Webmention</li>
+      <li>Linked Data Notifications</li>
+      <li>Micropub</li>
+      <li>WebSub</li>
+    </ul>
+    <p>
+      It will maintain errata and editor&apos;s drafts for the following Notes from the Social Web Working Group:
+    </p>
+    <ul>
+      <li>JF2</li>
+      <li>Post Type Discovery</li>
+      <li>Social Web Protocols</li>
+      <li>IndieAuth</li>
+    </ul>
+    <p>
+      The group will maintain the Activity Streams 2.0 JSON-LD context document and add new extension terms as they become widely implemented.
+    </p>
+    <p>
+      The group will maintain the Activity Streams 2.0 OWL ontology.
+    </p>
+    <p>
+      The group will develop extensions to ActivityPub and Activity Streams 2.0, and other specifications as needed, to address new use cases and requirements.
+    </p>
+    <p>
+      The group will develop and document integration between ActivityPub and other protocols in a social web stack, such as Webfinger, HTML, and HTTP Signature.
+    </p>
+    <p>
+      The group will develop and support the development of test suites and reference implementations for the above specifications and extensions.
+    </p>
+    <p>
+      The group will provide an interface and touchpoint for other W3C groups and external organizations working with these specifications.
+    </p>
+    <p>
+      The group will provide information for implementers of these specifications, including best practices, tutorials, and examples.
     </p>
       <h3 id="out-of-scope">
         Out of Scope
@@ -83,7 +114,7 @@
       <p class="remove">
         {TBD: Identify topics known in advance to be out of scope}
       </p>
-      
+
     <h2 id="deliverables">
       Deliverables
     </h2>


### PR DESCRIPTION
I added what I think is a minimal scope of work:

- maintaining the outputs of the WG
- document integrations with other parts of the stack
- create extensions
- educate implementers
- contact point for other standards groups

I'd recommend merging this PR and making additional changes afterwards.

Closes #16 