### PR TITLE
fix: remove "Specifications"

### DIFF
--- a/CGCharter-1727386911.html
+++ b/CGCharter-1727386911.html
@@ -62,7 +62,7 @@
         Incubate new proposals which build on or complement the Social Web WG recommendations.
       </li>
     </ul>
-  
+
     <h2 id="scope-of-work">
       Scope of Work
     </h2>
@@ -83,20 +83,10 @@
       <p class="remove">
         {TBD: Identify topics known in advance to be out of scope}
       </p>
-      
+
     <h2 id="deliverables">
       Deliverables
     </h2>
-    <h3 id="specifications">
-      Specifications
-    </h3>
-    <p class="remove">
-      {TBD: Provide a brief description of each specification the group plans
-      to produce. Where an estimate is possible, it can be useful to provide an
-      estimated schedule for key deliverables. As described below, the group
-      may later modify the charter deliverables. if no specifications, include:
-      "No Specifications will be produced under the current charter."}
-    </p>
     <h3 id="non-normative-reports">
       Non-Normative Reports
     </h3>


### PR DESCRIPTION
We don't have any particular specifications to work on in our scope, so it probably makes sense to remove this section, and concentrate on "Non-normative Reports" instead.

Closes #23 