### PR TITLE
fix: remove inapplicable comment about test suites

### DIFF
--- a/CGCharter-1727386911.html
+++ b/CGCharter-1727386911.html
@@ -62,7 +62,7 @@
         Incubate new proposals which build on or complement the Social Web WG recommendations.
       </li>
     </ul>
-  
+
     <h2 id="scope-of-work">
       Scope of Work
     </h2>
@@ -83,7 +83,7 @@
       <p class="remove">
         {TBD: Identify topics known in advance to be out of scope}
       </p>
-      
+
     <h2 id="deliverables">
       Deliverables
     </h2>
@@ -108,12 +108,6 @@
     <h3 id="test-suites">
       Test Suites and Other Software
     </h3>
-    <p class="remove">
-      {TBD: If there are no plans to create a test suite or other software,
-      please state that and remove the following paragraph. If Github is not
-      being used, then indicate where the license information is. If GitHub is
-      being used link to your LICENSE.md file in the next paragraph.}
-    </p>
     <p>
       The group MAY produce test suites to support the Specifications. Please
       see the GitHub LICENSE file for test suite contribution licensing


### PR DESCRIPTION
Remove the comment section about test suites.

It recommends to add a link to the LICENSE file, but since we may have multiple repositories with (maybe?) different licenses, I left it unlinked.

Closes #25 