### PR TITLE
fix: remove warning about not using GitHub, since we use it

### DIFF
--- a/CGCharter-1727386911.html
+++ b/CGCharter-1727386911.html
@@ -62,7 +62,7 @@
         Incubate new proposals which build on or complement the Social Web WG recommendations.
       </li>
     </ul>
-  
+
     <h2 id="scope-of-work">
       Scope of Work
     </h2>
@@ -83,7 +83,7 @@
       <p class="remove">
         {TBD: Identify topics known in advance to be out of scope}
       </p>
-      
+
     <h2 id="deliverables">
       Deliverables
     </h2>
@@ -177,11 +177,6 @@
       "http://www.w3.org/Consortium/Legal/2015/copyright-software-and-document">
       W3C Software and Document License</a>. All other documents produced by
       the group should use that License where possible.
-    </p>
-    <p class="remove">
-      {TBD: if CG doesn't use GitHub replace the remaining paragraphs in this
-      section with: "All Contributions are made on the groups public mail list
-      or public contrib list"}
     </p>
     <p>
       Community Group participants agree to make all contributions in the


### PR DESCRIPTION
Since we use GitHub, it makes sense for us to remove the warning for groups that don't use GitHub. Closes #28.