### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,12 @@ When in doubt, email the mailing list!
 
 ## Previewing
 
+You can preview the most recent versions on the main branch here:
+
+- [Community Group Charter](https://swicg.github.io/potential-charters/CGCharter-1727386911.html) (proposed)
+- [Stage Process](https://swicg.github.io/potential-charters/stage-process)
+- [Working Group Charter](https://swicg.github.io/potential-charters/ap-maintenance-wg-charter.html) (ActivityPub-only, maintenance only)
+- [Working Group Charter](https://swicg.github.io/potential-charters/social-web-maintenance-wg-charter.html) (All Social Web Working Group documents, maintenance only)
+
 We recommend previewing your own PRs by simply opening the HTML file in a browser (locally), and previewing those of others by clicking into the "Files" view of each PR and selecting "View File" from the `...` menu, then "download".
 Note: on mobile, this _may_ download as a `.txt` file, which may need to be renamed/retyped locally before opening.)


### PR DESCRIPTION
Add links to the most recent `main` versions of the charters and staging process to the README so they're easier to find.