### PR TITLE
Assessing consensus in the CG Charter

### DIFF
--- a/CGCharter-1727386911.html
+++ b/CGCharter-1727386911.html
@@ -219,12 +219,11 @@
       Decision Process
     </h2>
     <p>
-      This group will seek to make decisions where there is consensus. Groups
-      are free to decide how to make decisions (e.g. Participants who have
+      This group will seek to make decisions where there is consensus. The Group makes decisions in the following ways: either Participants who have
       earned Committer status for a history of useful contributions assess
       consensus, or the Chair assesses consensus, or where consensus isn't
       clear there is a Call for Consensus [CfC] (see below) to allow multi-day
-      online feedback for a proposed course of action). It is expected that
+      online feedback for a proposed course of action. It is expected that
       participants can earn Committer status through a history of valuable
       discursive contributions as is common in open source projects.
       After discussion and due consideration of different opinions, a decision


### PR DESCRIPTION
Fixes #30 

The charter template says the group can choose how to assess consensus. This change says that the group can use one of three methods: Committers decide, Chair decides, or a call-for-consensus.