### PR TITLE
feat: define Committer role, remove expectations from Decision Making

### DIFF
--- a/CGCharter-1727386911.html
+++ b/CGCharter-1727386911.html
@@ -466,7 +466,7 @@
     </h2>
 
     <p>
-      A <dfn>Committer</dfn> is authorized to make changes to one or more GitHub repositories that are managed by the group. Participants can earn Committer status through a history of useful contributions. Granting Committer status is made through consensus, as discussed in <a href="#decision">Decision Process</a>. There is no limit to the number of Committers in the group or on a repository. There is no time limit on Committer status. Each repository for ongoing work items should have at least one active Committer other than the Chairs. Chair(s) can revoke Committer status for any reason. A Committer can give up the role voluntarily.
+      A <dfn>Committer</dfn> is authorized to make changes to one or more GitHub repositories that are managed by the group. Participants can earn Committer status through a history of useful contributions. Committer status is granted through consensus, as discussed in <a href="#decision">Decision Process</a>. There is no limit to the number of Committers in the group or on a repository. There is no time limit on Committer status. Each repository for ongoing work items should have at least one active Committer other than the Chairs. Chair(s) can revoke Committer status for any reason. A Committer can give up the role voluntarily.
     </p>
 
     <h2 id="charter-change">

--- a/CGCharter-1727386911.html
+++ b/CGCharter-1727386911.html
@@ -466,7 +466,7 @@
     </h2>
 
     <p>
-      A <dfn>Committer</dfn> is authorized to make changes to one or more GitHub repositories that are managed by the group. Participants can earn Committer status through a history of useful contributions. Granting Committer status is made through consensus, as discussed in <a href="#decision">Decision Process</a>. There is no limit to the number of Committers in the group or on a repository. There is no time limit on Committer status. Each repository should have at least one active Committer. Chair(s) can revoke Committer status for any reason. A Committer can give up the role voluntarily.
+      A <dfn>Committer</dfn> is authorized to make changes to one or more GitHub repositories that are managed by the group. Participants can earn Committer status through a history of useful contributions. Granting Committer status is made through consensus, as discussed in <a href="#decision">Decision Process</a>. There is no limit to the number of Committers in the group or on a repository. There is no time limit on Committer status. Each repository for ongoing work items should have at least one active Committer other than the Chairs. Chair(s) can revoke Committer status for any reason. A Committer can give up the role voluntarily.
     </p>
 
     <h2 id="charter-change">

--- a/CGCharter-1727386911.html
+++ b/CGCharter-1727386911.html
@@ -466,7 +466,7 @@
     </h2>
 
     <p>
-      A <dfn>Committer</dfn> is authorized to make changes to one or more GitHub repositories that are managed by the group. Participants can earn Committer status through a history of useful contributions. Committer status is granted through consensus, as discussed in <a href="#decision">Decision Process</a>. There is no limit to the number of Committers in the group or on a repository. There is no time limit on Committer status. Each repository for ongoing work items should have at least one active Committer other than the Chairs. Chair(s) can revoke Committer status for any reason. A Committer can give up the role voluntarily.
+      A <dfn>Committer</dfn> is authorized to make changes to one or more GitHub repositories that are managed by the group. Participants can earn Committer status through a history of useful contributions. Committer status is granted through consensus, as discussed in <a href="#decision">Decision Process</a>. There is no limit to the number of Committers in the group or on a repository. There is no time limit on Committer status. Each repository for ongoing work items should have at least one active Committer other than the Chairs. Chair(s) can revoke Committer status for any reason, and will notify the community. A Committer can give up the role voluntarily.
     </p>
 
     <h2 id="charter-change">

--- a/CGCharter-1727386911.html
+++ b/CGCharter-1727386911.html
@@ -234,13 +234,10 @@
       Decision Process
     </h2>
     <p>
-      This group will seek to make decisions where there is consensus. The Group makes decisions in the following ways: either Participants who have
-      earned Committer status for a history of useful contributions assess
+      This group will seek to make decisions where there is consensus. The Group makes decisions in the following ways: either Committers assess
       consensus, or the Chair assesses consensus, or where consensus isn't
       clear there is a Call for Consensus [CfC] (see below) to allow multi-day
-      online feedback for a proposed course of action. It is expected that
-      participants can earn Committer status through a history of valuable
-      discursive contributions as is common in open source projects.
+      online feedback for a proposed course of action.
       After discussion and due consideration of different opinions, a decision
       should be publicly recorded (where GitHub is used as the resolution
       of an Issue).
@@ -463,6 +460,14 @@
         communication as described above.
       </li>
     </ul>
+
+    <h2 id="committers">
+      Committers
+    </h2>
+
+    <p>
+      A <dfn>Committer</dfn> is authorized to make changes to one or more GitHub repositories that are managed by the group. Participants can earn Committer status through a history of useful contributions. Granting Committer status is made through consensus, as discussed in <a href="#decision">Decision Process</a>. There is no limit to the number of Committers in the group or on a repository. There is no time limit on Committer status. Each repository should have at least one active Committer. Chair(s) can revoke Committer status for any reason. A Committer can give up the role voluntarily.
+    </p>
 
     <h2 id="charter-change">
       Amendments to this Charter


### PR DESCRIPTION
This PR closes #48 . It gives a definition of the Committer status and some common-sense rules for becoming a Committer, the responsibilities, and ending Committer status.

The PR also takes out the language in Decision Making about an expected Committer role, since it's now defined.