### PR TITLE
drop dependencies boilerplate

### DIFF
--- a/CGCharter-1727386911.html
+++ b/CGCharter-1727386911.html
@@ -139,13 +139,6 @@
       see the GitHub LICENSE file for test suite contribution licensing
       information.
     </p>
-    <h2 id="liaisons">
-      Dependencies or Liaisons
-    </h2>
-    <p class="remove">
-      {TBD: List any significant dependencies on other groups (inside or
-      outside W3C) or materials. }
-    </p>
     <h2 id="process">
       Community and Business Group Process
     </h2>


### PR DESCRIPTION
no significant dependencies on other groups, so drop per guidance in template