### PR TITLE
editorial: Social Web WG link and year

### DIFF
--- a/CGCharter-1727386911.html
+++ b/CGCharter-1727386911.html
@@ -50,8 +50,8 @@
     </ul>
     <p>
       The Social Web Incubator Community Group (also known as SocialCG, or
-      SWICG) is the successor of the Social Web Working Group, which ran from
-      2014 to 2017.
+      SWICG) is the successor of the [Social Web Working Group](https://www.w3.org/wiki/Socialwg), which ran from
+      2014 to 2018.
     </p>
     <h2 id="goals">
       Goals


### PR DESCRIPTION
minor edits to link Social Web WG and correct the end year per the link. moved some fixes from https://github.com/swicg/potential-charters/pull/50/files into its own PR per suggestion from @ThisIsMissEm