### PR TITLE
feat: note the relationship with decisions made since the CG was started

### DIFF
--- a/CGCharter-1727386911.html
+++ b/CGCharter-1727386911.html
@@ -472,6 +472,15 @@
       A <dfn>Committer</dfn> is authorized to make changes to one or more GitHub repositories that are managed by the group. Participants can earn Committer status through a history of useful contributions. Committer status is granted through consensus, as discussed in <a href="#decision">Decision Process</a>. There is no limit to the number of Committers in the group or on a repository. There is no time limit on Committer status. Each repository for ongoing work items should have at least one active Committer other than the Chairs. Chair(s) can revoke Committer status for any reason, and will notify the community. A Committer can give up the role voluntarily.
     </p>
 
+    <h2 id="past-decisions">
+      Decisions made prior to Adoption of this Charter
+    </h2>
+
+    <p>
+      From 2017 to 2024, the SocialCG operated under the same process as its predecessor, the Social Web Working Group. Where they conflict, the
+      terms of this charter supercede any decisions made during that time. All decisions made during that time that are compatible with this charter stand.
+    </p>
+
     <h2 id="charter-change">
       Amendments to this Charter
     </h2>


### PR DESCRIPTION
Issue #9 asks for clarification on the relationship of the charter with previous decisions made by the group (such as starting task forces, or approving errata, or adding terms). This new section notes that where there are conflicts, the charter takes precedence, but if there are no conflicts, the decisions stand.