### PR TITLE
fix: combine and link sections on calls for consensus

### DIFF
--- a/CGCharter-1727386911.html
+++ b/CGCharter-1727386911.html
@@ -227,9 +227,11 @@
       Decision Process
     </h2>
     <p>
-      This group will seek to make decisions where there is consensus. The Group makes decisions in the following ways: either Committers assess
-      consensus, or the Chair assesses consensus, or where consensus isn't
-      clear there is a <a href="#calls-for-consensus">Call for Consensus</a>  [CfC] (see below) to allow multi-day
+      This group will seek to make decisions where there is consensus. The
+      Group makes decisions in the following ways: either Committers assess
+      consensus; the Chair assesses consensus; or, where consensus isn't
+      clear, there is a <a href="#calls-for-consensus">Call for Consensus</a>
+      [CfC] (see below) to allow multi-day
       online feedback for a proposed course of action.
       After discussion and due consideration of different opinions, a decision
       should be publicly recorded (where GitHub is used as the resolution
@@ -257,7 +259,10 @@
     </h3>
     <p>
       A call for consensus (CfC) will be issued for all resolutions via
-      email to public-swicg@w3.org. The presence of formal resolutions will be indicated by a "CfC" prefix in the subject line of an email on the list. Additional outreach to community venues for more affirmative consent is strongly encouraged.
+      email to public-swicg@w3.org. The presence of formal resolutions will be
+      indicated by a "CfC" prefix in the subject line of an email on the list.
+      Additional outreach to community venues for more affirmative consent is
+      strongly encouraged.
     </p>
     <p>
       There will be

--- a/CGCharter-1727386911.html
+++ b/CGCharter-1727386911.html
@@ -270,7 +270,7 @@
     <p>
       If no sustained objections are raised by the
       end of the response period, the resolution will be considered to have
-      consensus as a resolution of the Community Group, i.e. a group decision.
+      consensus as a resolution of the Community Group, i.e., a group decision.
       All decisions made by the group should be considered resolved unless and
       until new information becomes available or unless reopened at the
       discretion of the Chairs or the Director.

--- a/CGCharter-1727386911.html
+++ b/CGCharter-1727386911.html
@@ -229,7 +229,7 @@
     <p>
       This group will seek to make decisions where there is consensus. The Group makes decisions in the following ways: either Committers assess
       consensus, or the Chair assesses consensus, or where consensus isn't
-      clear there is a Call for Consensus [CfC] (see below) to allow multi-day
+      clear there is a <a href="#calls-for-consensus">Call for Consensus</a>  [CfC] (see below) to allow multi-day
       online feedback for a proposed course of action.
       After discussion and due consideration of different opinions, a decision
       should be publicly recorded (where GitHub is used as the resolution
@@ -250,25 +250,25 @@
       To afford asynchronous decisions and organizational deliberation, any
       resolution (including publication decisions) taken in a face-to-face
       meeting or teleconference will be considered provisional.
-      A call for consensus (CfC) will be issued for all resolutions via
-      email to public-swicg@w3.org, preferably with the abbreviation CfC early
-      in the subject line to catch more attention.
-    </p>
-    <p>
-      Any group participant may object to a
-      decision reached at an online or in-person meeting within 14 days of
-      publication of the decision, provided that they include
-      clear reasons for their objection grounded in the scope and documented
-      goals of the CG and its work items.
+      A <a href="#calls-for-consensus">call for consensus</a> (CfC) will be issued for all resolutions.
     </p>
     <h3 id="calls-for-consensus">
       Calls for Consensus
     </h3>
     <p>
-      The presence of formal resolutions will be indicated by a "CfC" prefix in
-      the subject line of an email on the list. Additional outreach to community
-      venues for more affirmative consent is strongly encouraged. There will be
-      a response period of 14 days. If no sustained objections are raised by the
+      A call for consensus (CfC) will be issued for all resolutions via
+      email to public-swicg@w3.org. The presence of formal resolutions will be indicated by a "CfC" prefix in the subject line of an email on the list. Additional outreach to community venues for more affirmative consent is strongly encouraged.
+    </p>
+    <p>
+      There will be
+      a response period of 14 days. Any group participant may object to a
+      decision reached at an online or in-person meeting within 14 days of
+      publication of the decision, provided that they include
+      clear reasons for their objection grounded in the scope and documented
+      goals of the CG and its work items.
+    </p>
+    <p>
+      If no sustained objections are raised by the
       end of the response period, the resolution will be considered to have
       consensus as a resolution of the Community Group, i.e. a group decision.
       All decisions made by the group should be considered resolved unless and


### PR DESCRIPTION
This closes #55 . I combined the discussion of CFC processes into a single section, and linked it from the other places the topic was mentioned.