### PR TITLE
Specify ranked choice voting as chair election mechanism.

### DIFF
--- a/CGCharter-1727386911.html
+++ b/CGCharter-1727386911.html
@@ -312,11 +312,10 @@
         candidate, that person becomes the Chair. If there are two or more
         candidates, there is a vote. Otherwise, nothing changes.
       </li>
-      <li>Participants vote. Participants have 21 days to vote for a single
-        candidate, but this period ends as soon as all participants have voted.
-        The individual who receives the most votes, no two from the same
-        organisation, is elected chair. In case of a tie, RFC2777 is used to
-        break the tie. An elected Chair may appoint co-Chairs.
+      <li>To elect one of multiple candidates, a vote will be held by the
+        election mechanism of ranked choice voting, in which voters rank
+        candidates by preference on their ballots. An elected Chair may appoint
+        co-Chairs.
       </li>
     </ol>
     <p>

--- a/CGCharter-1727386911.html
+++ b/CGCharter-1727386911.html
@@ -313,9 +313,12 @@
         candidates, there is a vote. Otherwise, nothing changes.
       </li>
       <li>To elect one of multiple candidates, a vote will be held by the
-        election mechanism of ranked choice voting, in which voters rank
-        candidates by preference on their ballots. An elected Chair may appoint
-        co-Chairs.
+        election mechanism of ranked choice voting (no two votes may be from
+        the same organization), in which voters rank candidates by preference on
+        their ballots.
+      </li>
+      <li>An elected Chair may appoint co-Chairs (no two co-chairs may be from
+        the same organization, however).
       </li>
     </ol>
     <p>


### PR DESCRIPTION
Tweaks the boilerplate CG charter template (see PR #66) and specify the chair election mechanism as ranked choice voting.