### PR TITLE
less simple Scope language that gates active maintenance on editor-champions (in big-tent WG charter)

### DIFF
--- a/social-web-maintenance-wg-charter.html
+++ b/social-web-maintenance-wg-charter.html
@@ -170,7 +170,7 @@
         <h2>Scope</h2>
 
         <p>
-          The Working Group will maintain the
+          Where an active Editor and at least one member unaffiliated with that Editor have volunteered and been approved by the Community Group, the Working Group can maintain any of the deliverables of the previous Social Web Working Group:
           <a href="https://www.w3.org/TR/activitypub/">ActivityPub</a>,
           <a href="https://www.w3.org/TR/websub/">WebSub</a>,
           <a href="https://www.w3.org/TR/activitystreams-core/">Activity Streams</a>,


### PR DESCRIPTION
See discussion on #72 , to which this is an either/or alternative.