### PR TITLE
rename social-web-maintenance-wg-charter.html to social-web-wg

### DIFF
--- a/social-web-wg-charter.html
+++ b/social-web-wg-charter.html
@@ -336,7 +336,7 @@
           This group is expected to coordinate with the
           <a href="https://www.w3.org/groups/cg/socialcg/">Social Web Incubator Community Group</a>
           on consensus-based proposals related to content changes for the
-          Working Group Deliverables.
+          Social Web Working Group Deliverables.
           The Chairs of this group should reject proposals that are incompatible
           with this Charter.
         </p>

--- a/social-web-wg-charter.html
+++ b/social-web-wg-charter.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 
-    <title>Social Web Maintenance Working Group Charter</title>
+    <title>Social Web Working Group Charter</title>
 
     <link rel="stylesheet" href="https://www.w3.org/2005/10/w3cdoc.css" type="text/css" media="screen">
     <link rel="stylesheet" type="text/css" href="https://www.w3.org/OldGuide/pubrules-style.css">
@@ -71,19 +71,19 @@
     </header>
 
     <main>
-      <h1 id="title"><i class="todo">DRAFT</i> Social Web Maintenance Working Group Charter</h1>
+      <h1 id="title"><i class="todo">DRAFT</i> Social Web Working Group Charter</h1>
       <!-- replace DRAFT with PROPOSED when the AC reivew starts -->
       <!-- delete PROPOSED after AC review completed -->
 
       <p class="mission">The <strong>mission</strong> of the
-          <a href="https://www.w3.org/groups/wg/social/">Social Web Maintenance Working Group</a>
+          <a href="https://www.w3.org/groups/wg/social/">Social Web Working Group</a>
         is to maintain the W3C Recommendations, as well as related Notes, in the
         area of Social Web.
       </p>
 
       <div class="noprint">
         <p class="join">
-          <a href="https://www.w3.org/groups/wg/social/join/">Join the Social Web Maintenance Working Group.</a>
+          <a href="https://www.w3.org/groups/wg/social/join/">Join the Social Web Working Group.</a>
         </p>
       </div>
 
@@ -336,7 +336,7 @@
           This group is expected to coordinate with the
           <a href="https://www.w3.org/groups/cg/socialcg/">Social Web Incubator Community Group</a>
           on consensus-based proposals related to content changes for the
-          ActivityPub Maintenance Working Group Deliverables.
+          Working Group Deliverables.
           The Chairs of this group should reject proposals that are incompatible
           with this Charter.
         </p>
@@ -404,10 +404,10 @@
         <p>
           Information about the group (including details about deliverables,
           issues, actions, status, participants, and meetings)
-          will be available from the <a href="">Social Web Maintenance Working Group home page.</a>
+          will be available from the <a href="">Social Web Working Group home page.</a>
         </p>
         <p>
-          Most Social Web Maintenance Working Group teleconferences will focus on discussion
+          Most Social Web Working Group teleconferences will focus on discussion
           of particular specifications, and will be conducted on an as-needed basis.
         </p>
         <p>


### PR DESCRIPTION
remove "maintenance" from the name of the WG and the file name. scope is still "maintain" inside.

Per RESOLUTION of 2025-03-21 SocialCG meeting to remove "Maintenance" from potential WG names