### PR TITLE
rename ap-maintenance-wg-charter.html to ap-wg-charter.html

### DIFF
--- a/ap-wg-charter.html
+++ b/ap-wg-charter.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 
-    <title>ActivityPub Maintenance Working Group Charter</title>
+    <title>ActivityPub Working Group Charter</title>
 
     <link rel="stylesheet" href="https://www.w3.org/2005/10/w3cdoc.css" type="text/css" media="screen">
     <link rel="stylesheet" type="text/css" href="https://www.w3.org/OldGuide/pubrules-style.css">
@@ -71,19 +71,19 @@
     </header>
 
     <main>
-      <h1 id="title"><i class="todo">DRAFT</i> ActivityPub Maintenance Working Group Charter</h1>
+      <h1 id="title"><i class="todo">DRAFT</i> ActivityPub Working Group Charter</h1>
       <!-- replace DRAFT with PROPOSED when the AC reivew starts -->
       <!-- delete PROPOSED after AC review completed -->
 
       <p class="mission">The <strong>mission</strong> of the
-          <a href="https://www.w3.org/groups/wg/ap/">ActivityPub Maintenance Working Group</a>
+          <a href="https://www.w3.org/groups/wg/ap/">ActivityPub Working Group</a>
         is to maintain the ActivityPub, ActivityStreams and ActivityVocabulary
         W3C Recommendations, as well as related Notes.
       </p>
 
       <div class="noprint">
         <p class="join">
-          <a href="https://www.w3.org/groups/wg/ap/join/">Join the ActivityPub Maintenance Working Group.</a>
+          <a href="https://www.w3.org/groups/wg/ap/join/">Join the ActivityPub Working Group.</a>
         </p>
       </div>
 
@@ -304,7 +304,7 @@
           This group is expected to coordinate with the
           <a href="https://www.w3.org/groups/cg/socialcg/">Social Web Incubator Community Group</a>
           on consensus-based proposals related to content changes for the
-          ActivityPub Maintenance Working Group Deliverables.
+          ActivityPub Working Group Deliverables.
           The Chairs of this group should reject proposals that are incompatible
           with this Charter.
         </p>
@@ -372,10 +372,10 @@
         <p>
           Information about the group (including details about deliverables,
           issues, actions, status, participants, and meetings)
-          will be available from the <a href="">ActivityPub Maintenance Working Group home page.</a>
+          will be available from the <a href="">ActivityPub Working Group home page.</a>
         </p>
         <p>
-          Most ActivityPub Maintenance Working Group teleconferences will focus on discussion
+          Most ActivityPub Working Group teleconferences will focus on discussion
           of particular specifications, and will be conducted on an as-needed basis.
         </p>
         <p>


### PR DESCRIPTION
remove "Maintenance" from WG name. keep "maintain" in the charter scope

Per RESOLUTION of 2025-03-21 SocialCG meeting to remove "Maintenance" from potential WG names