### PR TITLE
Add "workflow" section to Scope section of WG charters

### DIFF
--- a/social-web-maintenance-wg-charter.html
+++ b/social-web-maintenance-wg-charter.html
@@ -194,22 +194,23 @@
           <h3 id="workflow-for-active-items">Workflow for Active Items</h3>
           <p>
             It is important to the health of the group and the quality of review
-            to avoid Chair focus and Working Group review from being too much
-            parallel work being scheduled concurrently. For this reason, the
-            Chair(s) may choose to stagger the shcedulings of kick-offs and
-            active work, or even defer final Chair and member review of items
-            into a queue, if they feel they cannot adequately supervise too many
-            such processes in parallel. The amount of effort and time needed to
-            support work items varies; even for a given work item, support may
-            require more from one chair than another based on familiarity or
-            expertise, so rather than set a fixed quota, it is expected that
-            Chairs be open and public about these constraints, and especially
-            clear with Editors and champions in the process of rallying support
-            for items entering that queue.
+            to avoid too much parallel work being scheduled concurrently. For
+            this reason, the Chair(s) may choose to stagger the schedulings of
+            kick-offs, active work, and review of work items, or even defer
+            final Chair and member review of items into a queue, if they feel
+            they cannot adequately supervise too many such processes in
+            parallel. The amount of effort and time needed to support work items
+            varies; even for a given work item, support may require more from
+            one chair than another based on familiarity or expertise, so rather
+            than set a fixed quota, it is expected that Chairs be open and
+            public about these constraints, and especially clear with Editors
+            and champions in the process of rallying support for items entering
+            that queue.
           </p>
           <p>
-            If there is substantial amount of work being queued, the Chair(s)
-            are invited to recruit additional Chairs and call elections for an
+            If there is substantial amount of work being queued, or if work is
+            ramping up outside the expertise of the current Chair(s), these are
+            invited to recruit additional Chairs and call elections for an
             additional co-Chair.
           </p>
         </section>

--- a/social-web-maintenance-wg-charter.html
+++ b/social-web-maintenance-wg-charter.html
@@ -190,6 +190,31 @@
           </p>
         </section>
 
+        <section id="section-workflow-for-active-items">
+          <h3 id="workflow-for-active-items">Workflow for Active Items</h3>
+          <p>
+            It is important to the health of the group and the quality of review
+            to avoid Chair focus and Working Group review from being too much
+            parallel work being scheduled concurrently. For this reason, the
+            Chair(s) may choose to stagger the shcedulings of kick-offs and
+            active work, or even defer final Chair and member review of items
+            into a queue, if they feel they cannot adequately supervise too many
+            such processes in parallel. The amount of effort and time needed to
+            support work items varies; even for a given work item, support may
+            require more from one chair than another based on familiarity or
+            expertise, so rather than set a fixed quota, it is expected that
+            Chairs be open and public about these constraints, and especially
+            clear with Editors and champions in the process of rallying support
+            for items entering that queue.
+          </p>
+          <p>
+            If there is substantial amount of work being queued, the Chair(s)
+            are invited to recruit additional Chairs and call elections for an
+            additional co-Chair.
+          </p>
+        </section>
+
+
       </section>
 
       <section id="deliverables">

--- a/social-web-maintenance-wg-charter.html
+++ b/social-web-maintenance-wg-charter.html
@@ -201,17 +201,17 @@
             they cannot adequately supervise too many such processes in
             parallel. The amount of effort and time needed to support work items
             varies; even for a given work item, support may require more from
-            one chair than another based on familiarity or expertise, so rather
+            one Chair than another based on familiarity or expertise, so rather
             than set a fixed quota, it is expected that Chairs be open and
             public about these constraints, and especially clear with Editors
             and champions in the process of rallying support for items entering
             that queue.
           </p>
           <p>
-            If there is substantial amount of work being queued, or if work is
-            ramping up outside the expertise of the current Chair(s), these are
-            invited to recruit additional Chairs and call elections for an
-            additional co-Chair.
+            If there are substantial amounts of work being queued, or if work is
+            ramping up outside the expertise of the current Chair(s), the latter
+            are encouraged to recruit additional Chairs and call elections for
+            an additional co-Chair.
           </p>
         </section>
 


### PR DESCRIPTION
Hopefully closes #83 

To get the ball rolling on Evan's proposal that Chairs be able to "queue" active work, I threw up a proposal. I didn't put a precise number on how much parallel work should be targeted per Chair, but left it loose; if someone feels strongly, I'd welcome a counter-PR that picks a value or range for "N" in Evan's email!

I only made this change to the big-tent charter, but once it's been reviewed I will copy-paste it into the other proposals as I did in other PRs in a last-minute commit. I think we will be glad this mechanism is already in place if we later incorporate staging-process work items and loosen the Class-4 ban! 